### PR TITLE
#48 [BUG]Users_stack account_id가 없는값 발생

### DIFF
--- a/src/main/java/com/eskiiimo/api/user/User.java
+++ b/src/main/java/com/eskiiimo/api/user/User.java
@@ -41,7 +41,7 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
     @Builder.Default
-    @OneToMany(fetch = FetchType.LAZY,cascade =  CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY,cascade =  CascadeType.ALL,orphanRemoval=true)
     @JoinColumn(name ="account_id")
     private List<UsersStack> stacks = new ArrayList<UsersStack>();
     private String contact;

--- a/src/main/java/com/eskiiimo/api/user/profile/ProfileDto.java
+++ b/src/main/java/com/eskiiimo/api/user/profile/ProfileDto.java
@@ -27,14 +27,32 @@ public class ProfileDto {
     private String description;
 
     public void updateProfile(User User) {
-        List<UsersStack> stackList = new ArrayList<UsersStack>();
+        List<UsersStack> removeList = new ArrayList<UsersStack>();
+        //Compare Stack List and Remove User's Stacks
+        for(UsersStack usersStack: User.getStacks()){
+            Boolean checkRemove=Boolean.TRUE;
+            for(TechnicalStack stack : this.stacks){
+                if(usersStack.getStack().equals(stack)){
+                    this.stacks.remove(stack);
+                    checkRemove=Boolean.FALSE;
+                    break;
+                }
+            }
+            if(checkRemove)
+                removeList.add(usersStack);
+        }
+        // Remove User's Stacks
+        for(UsersStack stack : removeList)
+            User.getStacks().remove(stack);
+
+        // add User's Stacks
+
         for(TechnicalStack stack : this.stacks){
             UsersStack usersStack = new UsersStack();
             usersStack.setStack(stack);
-            stackList.add(usersStack);
+            User.getStacks().add(usersStack);
         }
             User.setRole(this.role);
-            User.setStacks(stackList);
             User.setContact(this.contact);
             User.setArea(this.area);
             User.setLevel(this.level);

--- a/src/main/java/com/eskiiimo/api/user/profile/ProfileService.java
+++ b/src/main/java/com/eskiiimo/api/user/profile/ProfileService.java
@@ -42,8 +42,7 @@ public class ProfileService {
         User profile =  userRepository.findByUserId(user_id)
                 .orElseThrow(()-> new UserNotFoundException("존재하지 않는 사용자입니다."));
         updateData.updateProfile(profile);
-        this.userRepository.save(profile);
-        return updateData;
+        return  this.userRepository.save(profile).toProfileDto();
     }
 
     public Page<Project> getRunning(String user_id, Pageable pageable) {


### PR DESCRIPTION
- ProfileDto.updateProfile
  스택 리스트에서 검사후 데이터 삭제, 추가 진행하여 필요이상의 쿼리를 제거
- ProfileService
  입력받은 DTO를 반환하는것보단 실제 변경된 Dto를 보여주는게 바람직하다 판단되어 수정
- User
  stacks에 orphanRemoval=true 옵션 추가하여 엔티티에서 값이 제거되면 UsersStack테이블에서도 제거되게 수정