### PR TITLE
refactor: 조회 서비스 트랜잭션 readOnly로 변경

### DIFF
--- a/src/main/java/com/eskiiimo/web/projects/service/ProjectApplyService.java
+++ b/src/main/java/com/eskiiimo/web/projects/service/ProjectApplyService.java
@@ -85,7 +85,7 @@ public class ProjectApplyService {
         this.projectRepository.save(project);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ProjectApplicantDto> getApplicants(Long projectId, String visitorId) {
         Project project = getProjectForLeader(projectId, visitorId);
 

--- a/src/main/java/com/eskiiimo/web/projects/service/ProjectDetailService.java
+++ b/src/main/java/com/eskiiimo/web/projects/service/ProjectDetailService.java
@@ -56,14 +56,14 @@ public class ProjectDetailService {
         return this.projectToDto(this.projectRepository.save(project));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ProjectDetailDto getProject(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectNotFoundException(projectId));
         return this.projectToDto(project);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<RecruitDto> getRecruits(String visitorId, Long projectId) {
         getProjectForLeader(projectId, visitorId);
         List<Recruit> recruits = this.recruitRepository.findAllByProject_ProjectId(projectId)

--- a/src/main/java/com/eskiiimo/web/projects/service/ProjectListService.java
+++ b/src/main/java/com/eskiiimo/web/projects/service/ProjectListService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +20,7 @@ public class ProjectListService {
     2. 직군별, 분야별 둘 중 하나만 선택되어있을 경우
     3.       ...     둘다 선택되어있지 않을 경우
     */
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getAllByField(String occupation, ProjectField field, Pageable pageable) {
         Page<ProjectListDto> page = this.projectRepository.findAllProjectedBy(pageable);
         if (occupation != null) {
@@ -62,6 +64,7 @@ public class ProjectListService {
         return page;
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> findAllByDdayLessThanOrderByDdayAsc(Pageable pageable) {
         Page<ProjectListDto> page = this.projectRepository.findAllByDdayLessThanOrderByDdayAsc(30, pageable);
         return page;

--- a/src/main/java/com/eskiiimo/web/projects/service/RecruitService.java
+++ b/src/main/java/com/eskiiimo/web/projects/service/RecruitService.java
@@ -44,7 +44,7 @@ public class RecruitService {
         this.recruitRepository.save(projectRecruit);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<RecruitDto> getRecruitList(String userId, String visitorId) {
         if (!userId.equals(visitorId))
             throw new RecruitNotAuthException();

--- a/src/main/java/com/eskiiimo/web/security/service/AuthService.java
+++ b/src/main/java/com/eskiiimo/web/security/service/AuthService.java
@@ -9,6 +9,7 @@ import com.eskiiimo.web.security.exception.CUserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -33,6 +34,7 @@ public class AuthService {
         return true;
     }
 
+    @Transactional(readOnly = true)
     public User signin(SignInDto signInDto) {
         Optional<User> optionalUser = userRepository.findByUserId(signInDto.getUserId());
         if(optionalUser.isEmpty())
@@ -43,6 +45,7 @@ public class AuthService {
         return user;
     }
 
+    @Transactional(readOnly = true)
     public boolean idCheck(String checkId) {
         Optional<User> optionalUser = userRepository.findByUserId(checkId);
         if(optionalUser.isEmpty())

--- a/src/main/java/com/eskiiimo/web/security/service/CustomUserDetailService.java
+++ b/src/main/java/com/eskiiimo/web/security/service/CustomUserDetailService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -13,6 +14,7 @@ public class CustomUserDetailService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String userPk) {
         return userRepository.findByUserId(userPk).orElseThrow(CUserNotFoundException::new);
     }

--- a/src/main/java/com/eskiiimo/web/user/service/PeopleService.java
+++ b/src/main/java/com/eskiiimo/web/user/service/PeopleService.java
@@ -11,8 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +23,7 @@ public class PeopleService {
     @Autowired
     UserRepository userRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<PeopleDto> getPeople(Long grade, ProjectRole role, String area, Pageable pageable){
         Page<User> page = userRepository.findAll(pageable);
 

--- a/src/main/java/com/eskiiimo/web/user/service/ProfileService.java
+++ b/src/main/java/com/eskiiimo/web/user/service/ProfileService.java
@@ -29,10 +29,11 @@ public class ProfileService {
 
     @Autowired
     ProjectRepository projectRepository;
+
     @Autowired
     ProjectMemberRepository projectMemberRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ProfileDto getProfile(String userId) {
         User profile = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
@@ -50,21 +51,25 @@ public class ProfileService {
         return this.userRepository.save(profile).toProfileDto();
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getRunning(String userId, Pageable pageable) {
         Page<ProjectListDto> page = this.projectRepository.findAllByProjectMembers_User_UserIdAndProjectMembers_HideAndState(userId, Boolean.FALSE, State.RUNNING, pageable);
         return page;
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getEnded(String userId, Pageable pageable) {
         Page<ProjectListDto> page = this.projectRepository.findAllByProjectMembers_User_UserIdAndProjectMembers_HideAndState(userId, Boolean.FALSE, State.ENDED, pageable);
         return page;
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getPlanner(String userId, Pageable pageable) {
         Page<ProjectListDto> page = this.projectRepository.findAllByLeaderIdAndProjectMembers_Hide(userId, Boolean.FALSE, pageable);
         return page;
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getHiddenRunning(String userId, String visitorId, Pageable pageable) {
         if (!userId.equals(visitorId))
             throw new NotYourProfileException(userId);
@@ -72,6 +77,7 @@ public class ProfileService {
         return page;
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getHiddenEnded(String userId, String visitorId, Pageable pageable) {
         if (!userId.equals(visitorId))
             throw new NotYourProfileException(userId);
@@ -79,6 +85,7 @@ public class ProfileService {
         return page;
     }
 
+    @Transactional(readOnly = true)
     public Page<ProjectListDto> getHiddenPlanner(String userId, String visitorId, Pageable pageable) {
         if (!userId.equals(visitorId))
             throw new NotYourProfileException(userId);


### PR DESCRIPTION
### Service Layer 내 조회 기능 관련 트랜잭션 readOnly로 변경하여 성능 최적화
  
**service 로직에 적용시킨 도메인**
- projects
- security
- user

Resolves: #96
See also: