### PR TITLE
bugfix: 테스트 실행 시 무한루프로 빠지는 에러

### DIFF
--- a/src/test/java/com/eskiiimo/web/user/profile/ReShowProjectTest.java
+++ b/src/test/java/com/eskiiimo/web/user/profile/ReShowProjectTest.java
@@ -4,7 +4,6 @@ import com.eskiiimo.repository.projects.model.Project;
 import com.eskiiimo.repository.user.model.User;
 import com.eskiiimo.web.common.BaseControllerTest;
 import com.eskiiimo.web.projects.enumtype.State;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -18,7 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("숨긴 프로젝트 취소하기")
-@Disabled
 public class ReShowProjectTest extends BaseControllerTest {
 
     @Test

--- a/src/test/java/com/eskiiimo/web/user/profile/UpdateProfileTest.java
+++ b/src/test/java/com/eskiiimo/web/user/profile/UpdateProfileTest.java
@@ -2,7 +2,6 @@ package com.eskiiimo.web.user.profile;
 
 import com.eskiiimo.web.common.BaseControllerTest;
 import com.eskiiimo.web.user.request.UpdateProfileRequest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -19,7 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Disabled
 @DisplayName("프로필 수정")
 public class UpdateProfileTest extends BaseControllerTest {
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,7 +6,7 @@ spring:
         show-sql: false
         format_sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
   jackson:
     deserialization:
       fail-on-unknown-properties : true


### PR DESCRIPTION
 ## 문제발생
 개별적으로 테스트 수행 시 성공하지만, 전체 테스트 수행 시 무한루프로 빠짐.

 ## 문제원인
 SpringBoot2.0부터 HikariCP로 Default Connection Pool이 변경됨.
 사용중인 Hikari Connection은 maxLifetime에 상관없이 제거되지 않으며 사용중이지 않을 때만 제거됨. 따라서 특정 시간 이후에 HikariPool이 제거될 때 기존에 설정되어있던 'ddl-auto: create-drop' 에 의해 table들이 전부 drop되어 다음 트랜잭션이 시작할 때 테이블을 찾지 못한다는 에러가 발생한 것.

 ## 문제해결
  ddl-auto의 설정값 변경 ( create-drop -> create )
  create : SessionFactory가 시작될 때 데이터베이스 drop을 실행하고 생성된 DDL을 실행시킴
  따라서 사용중이던 HikariPool이 제거되더라도 drop하지 않고 남겨둠으로써 문제 해결.

 Resolves: #135
 See also: #66