### PR TITLE
chore: actuator 활성화, SpringBootAdmin 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 		exclude module: 'junit'
 	}
 	compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: '2.3.1.RELEASE'
+	compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '2.3.2.RELEASE'
+	implementation 'de.codecentric:spring-boot-admin-starter-client:2.2.3'
 }
 
 test {
@@ -69,4 +71,12 @@ task copyRestDocs(type: Copy) {
 }
 bootJar {
 	dependsOn copyRestDocs
+}
+
+allprojects {
+	gradle.projectsEvaluated {
+		tasks.withType(JavaCompile) {
+			options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+		}
+	}
 }

--- a/src/main/java/com/eskiiimo/web/errorbot/util/AgentUtils.java
+++ b/src/main/java/com/eskiiimo/web/errorbot/util/AgentUtils.java
@@ -51,7 +51,15 @@ public class AgentUtils {
 
     public static Version getBrowserVersion(HttpServletRequest request) {
         UserAgent userAgent = getUserAgent(request);
-        return userAgent == null ? new Version("0", "0", "0") : userAgent.getBrowserVersion();
+        if (userAgent == null) {
+            return new Version("0", "0", "0");
+        } else {
+            Version version = userAgent.getBrowserVersion();
+            if (version == null)
+                return new Version("0", "0", "0");
+            else
+                return version;
+        }
     }
 
     public static BrowserType getBrowserType(HttpServletRequest request) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
 
   jackson:
     deserialization:
-      fail-on-unknown-properties : true
+      fail-on-unknown-properties: true
 
   servlet:
     multipart:
@@ -30,7 +30,19 @@ spring:
       charset: UTF-8
       enabled: true
       force: true
+  boot:
+    admin:
+      client:
+        url: http://egluubootadmin.herokuapp.com/
+        instance:
+          service-url: https://egluuapi.codingnome.dev/
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+        
 jwt:
   secretKey: EGLUUSecretKeyV1ThisDataMustBeHide
 


### PR DESCRIPTION
- SpringBootAdmin 연동과정에서 Browser 에러가 떠서 null Check 추가
- heroku에 배포되어있는 SpringBootAdmin 서버로 정보 전송
- 로컬에서 테스트 해보고싶으면 Service-url 을 수정해야함
- compile lint 옵션 활성화(Critical하진 않지만 어느정도의 문제가 되는 요소들을 검출해줌)
- heap dump를 수동으로 딸수는 있는거 같음

Resolves: #60