### PR TITLE
refactor: 이미지 업로드 요청에서 이미지가 첨부되지 않은경우 400에러 반환

### DIFF
--- a/src/main/java/com/eskiiimo/web/files/controller/FilesExceptionHandleController.java
+++ b/src/main/java/com/eskiiimo/web/files/controller/FilesExceptionHandleController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -29,4 +30,10 @@ public class FilesExceptionHandleController {
         return new ErrorResponse("303", exception.getMessage());
     }
 
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleMissingFiles(MissingServletRequestPartException exception) {
+        return new ErrorResponse("304", "파일이 첨부되지 않았습니다.");
+    }
 }

--- a/src/test/java/com/eskiiimo/web/files/controller/ProfileImageControllerTest.java
+++ b/src/test/java/com/eskiiimo/web/files/controller/ProfileImageControllerTest.java
@@ -56,6 +56,18 @@ class ProfileImageControllerTest extends BaseControllerTest {
         ;
     }
 
+    @Test
+    @DisplayName("프로필 이미지 업로드_이미지가 없을 때")
+    @WithMockUser(username="testuser")
+    void uploadProfileImageFailBecause_MissingRequestPart() throws Exception {
+        this.mockMvc.perform(RestDocumentationRequestBuilders.fileUpload("/profile/image/{user_id}","testuser")
+            .accept(MediaTypes.HAL_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andDo(print())
+            .andDo(document("304"))
+        ;
+    }
 
 
     @Test

--- a/src/test/java/com/eskiiimo/web/files/controller/ProjectImageControllerTest.java
+++ b/src/test/java/com/eskiiimo/web/files/controller/ProjectImageControllerTest.java
@@ -56,6 +56,17 @@ class ProjectImageControllerTest extends BaseControllerTest {
        ;
     }
 
+    @Test
+    @DisplayName("프로젝트 이미지 업로드_이미지가 없을 때")
+    @WithMockUser(username="testuser")
+    void uploadProjectImageFailBecause_MissingRequestPart() throws Exception {
+        this.mockMvc.perform(RestDocumentationRequestBuilders.fileUpload("/projects/image/{projectid}",1)
+            .accept(MediaTypes.HAL_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andDo(print())
+        ;
+    }
 
     @Test
     @DisplayName("프로젝트 이미지 다운로드")


### PR DESCRIPTION
서버에러가 아니라 잘못된 요청이기 때문에 500번 에러에서 400번 에러로 강등

@KimJinYounga @dev-kimdoyoung 

Resolves: #166